### PR TITLE
org.jetbrains.intellij版本升级及配置端口使用问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.3.2'
+    id 'org.jetbrains.intellij' version "0.4.1"
 }
 
 apply plugin: 'idea'

--- a/src/main/java/com/github/mustfun/mybatis/plugin/service/DbService.java
+++ b/src/main/java/com/github/mustfun/mybatis/plugin/service/DbService.java
@@ -61,7 +61,14 @@ public class DbService {
     }
 
     public  Connection getConnection(DbSourcePo configPo) {
-        DbUtil dbUtil = new DbUtil(configPo.getDbAddress(), configPo.getDbName(), configPo.getUserName(), configPo.getPassword());
+
+        DbUtil dbUtil;
+        if(configPo.getPort() == null){
+            dbUtil = new DbUtil(configPo.getDbAddress(), configPo.getDbName(), configPo.getUserName(), configPo.getPassword());
+        }else{
+            //if configured
+            dbUtil = new DbUtil(configPo.getDbAddress(), configPo.getDbName(), configPo.getUserName(), configPo.getPassword(), configPo.getPort());
+        }
         return dbUtil.getConnection();
     }
 

--- a/src/main/java/com/github/mustfun/mybatis/plugin/ui/UiGenerateUtil.java
+++ b/src/main/java/com/github/mustfun/mybatis/plugin/ui/UiGenerateUtil.java
@@ -25,8 +25,10 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.CheckBoxList;
 import com.intellij.util.ui.JBInsets;
 import com.intellij.util.ui.JBUI;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.Yaml;
+
 import javax.swing.*;
 import java.io.File;
 import java.io.FileInputStream;
@@ -34,7 +36,6 @@ import java.sql.Connection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -78,7 +79,9 @@ public final class UiGenerateUtil {
             DbSourcePo dbSourcePo = new DbSourcePo();
             dbSourcePo.setDbAddress(address);
             dbSourcePo.setDbName(dbName);
-            dbSourcePo.setPort(Integer.parseInt(port));
+            if (StringUtils.isNotBlank(port)) {
+                dbSourcePo.setPort(Integer.parseInt(port));
+            }
             dbSourcePo.setUserName(userName);
             dbSourcePo.setPassword(password);
             //连接数据库

--- a/src/main/java/com/github/mustfun/mybatis/plugin/ui/UiGenerateUtil.java
+++ b/src/main/java/com/github/mustfun/mybatis/plugin/ui/UiGenerateUtil.java
@@ -76,12 +76,19 @@ public final class UiGenerateUtil {
             String dbName = connectDbSetting.getDbName().getText();
             String userName = connectDbSetting.getUserName().getText();
             String password = connectDbSetting.getPassword().getText();
+            Integer p = null;
+            if (StringUtils.isNotBlank(port)) {
+                try {
+                    p = Integer.parseInt(port);
+                } catch (NumberFormatException e1) {
+                    Messages.showMessageDialog("端口配置不正确", "连接数据库提示", Messages.getInformationIcon());
+                    return;
+                }
+            }
             DbSourcePo dbSourcePo = new DbSourcePo();
+            dbSourcePo.setPort(p);
             dbSourcePo.setDbAddress(address);
             dbSourcePo.setDbName(dbName);
-            if (StringUtils.isNotBlank(port)) {
-                dbSourcePo.setPort(Integer.parseInt(port));
-            }
             dbSourcePo.setUserName(userName);
             dbSourcePo.setPassword(password);
             //连接数据库

--- a/src/main/java/com/github/mustfun/mybatis/plugin/util/DbUtil.java
+++ b/src/main/java/com/github/mustfun/mybatis/plugin/util/DbUtil.java
@@ -1,8 +1,5 @@
 package com.github.mustfun.mybatis.plugin.util;
 
-import com.intellij.openapi.application.PathManager;
-import com.intellij.util.PathUtil;
-
 import java.io.*;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -22,6 +19,16 @@ public class DbUtil {
 
     public DbUtil(String url, String dbName, String userName, String password){
         this.url = "jdbc:mysql://"+url+":3306/"+dbName+"?useUnicode=true&characterEncoding=utf8&autoReconnect=true&failOverReadOnly=false";
+        this.username = userName;
+        this.password = password;
+    }
+
+    /**
+     * 增加端口配置
+     * @date 2019/1/22
+     */
+    public DbUtil(String url, String dbName, String userName, String password, int port){
+        this.url = "jdbc:mysql://"+url+":"+port+"/"+dbName+"?useUnicode=true&characterEncoding=utf8&autoReconnect=true&failOverReadOnly=false";
         this.username = userName;
         this.password = password;
     }


### PR DESCRIPTION
1）org.jetbrains.intellij版本修改为0.4.1 否则本地编译(idea 2018.3.3)可能会报错Unable to load class 'org.gradle.api.publish.ivy.internal.artifact.DefaultIvyArtifact
2）修复不使用配置的端口的错误，增加端口配置校验提示